### PR TITLE
NSIMD: update version requirements to support CMake 4.0

### DIFF
--- a/dist/version.patch
+++ b/dist/version.patch
@@ -1,0 +1,12 @@
+diff -uw nsimd-3.0.1.orig/CMakeLists.txt nsimd-3.0.1/CMakeLists.txt
+--- nsimd-3.0.1.orig/CMakeLists.txt    2025-08-07 19:59:56.323564683 -0500
++++ nsimd-3.0.1/CMakeLists.txt 2025-08-07 20:00:16.062354082 -0500
+@@ -20,7 +20,7 @@
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ 
+-cmake_minimum_required(VERSION 3.0.2)
++cmake_minimum_required(VERSION 3.0.2...3.25.0)
+ project(NSIMD VERSION 3.0 LANGUAGES C CXX)
+ 
+ # -----------------------------------------------------------------------------

--- a/src/build.sh
+++ b/src/build.sh
@@ -37,6 +37,7 @@ echo "NSIMD: Unpacking archive..."
 pushd ${BUILD_DIR} >/dev/null
 ${TAR?} xf ${SRCDIR}/../dist/${NAME}.tar
 pushd ${NAME}
+${PATCH?} -p1 < ${SRCDIR}/../dist/version.patch
 ${PATCH?} -p1 < ${SRCDIR}/../dist/sleef_zip.patch
 # Some (ancient but still used) versions of patch don't support the
 # patch format used here but also don't report an error using the exit


### PR DESCRIPTION
record that CmakeList.txt works with cmake 3.25 so that cmake 4.0 does not abort. No updates available in upstream NSIMD it seems.